### PR TITLE
Resolve java standard libraries through java resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+.env

--- a/functional.spec.js
+++ b/functional.spec.js
@@ -108,6 +108,11 @@ describe('functional', () => {
     'https://www.slf4j.org/api/org/apache/log4j/Appender.html',
   );
   testBulk(
+    'java',
+    'java.util.List',
+    'https://docs.oracle.com/javase/9/docs/api/java/util/List.html',
+  );
+  testBulk(
     'ping',
     'https://nodejs.org/api/path.html',
     'https://nodejs.org/api/path.html',

--- a/src/java/index.js
+++ b/src/java/index.js
@@ -1,9 +1,46 @@
+const findReachableUrls = require('find-reachable-urls');
 const flatMappingList = require('./mapping');
+const cache = require('../utils/cache');
+
+const SUPPORTED_JAVA_VERSIONS = [9, 8, 7];
 
 module.exports = async function (pkg) {
-  const url = flatMappingList[pkg];
+  const targetAsPath = pkg.replace(/\./g, '/');
+  const isBuildIn = !!pkg.match(/^javax?/);
 
-  if (url) {
-    return url;
+  if (!isBuildIn) {
+    const url = flatMappingList[pkg];
+
+    if (url) {
+      return url;
+    }
   }
+
+  const cacheKey = `java_${pkg}`;
+  const cacheValue = await cache.get(cacheKey);
+
+  if (cacheValue) {
+    return cacheValue;
+  }
+
+  const urls = SUPPORTED_JAVA_VERSIONS.reduce(
+    (memo, version) => memo.concat(
+      `https://docs.oracle.com/javase/${version}/docs/api/${targetAsPath}.html`,
+      `https://docs.oracle.com/javaee/${version}/api/${targetAsPath}.html`,
+    ),
+    [],
+  );
+
+  const reachableUrl = await findReachableUrls(
+    urls,
+    { firstMatch: true },
+  );
+
+  if (!reachableUrl) {
+    return undefined;
+  }
+
+  await cache.set(cacheKey, reachableUrl);
+
+  return reachableUrl;
 };

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -13,6 +13,7 @@ const log = require('./log');
 // sfo1 - San Francisco, CA, USA
 
 const redisUrls = {
+  dev1: 'sprightly-lavender-4454.redisgreen.net',
   bru1: 'sprightly-lavender-4454.redisgreen.net',
   gru1: 'handsome-turtle-8352.redisgreen.net',
   hnd1: 'inventive-willow-2140.redisgreen.net',
@@ -20,7 +21,7 @@ const redisUrls = {
   sfo1: 'graceful-turnip-982.redisgreen.net',
 };
 
-const availableRegions = ['bru1', 'gru1', 'hnd1', 'iad1', 'sfo1'];
+const availableRegions = ['dev1', 'bru1', 'gru1', 'hnd1', 'iad1', 'sfo1'];
 
 let redis;
 const simpleCache = new Map();


### PR DESCRIPTION
Before java standard library were resolved through the ping plugin. This plugin was called with different possible url combinations which caused an unnecessary delay. By using `find-reachable-urls` the first url which response with 200 will be returned.