### PR TITLE
Add dev server for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ Response:
 
 Install dependencies:
 
-`yarn install`
+`npm install`
 
 Run server:
 
-`yarn start`
+`npm run dev`
 
 ## Testing
 
-`yarn test`
+`npm test`
 
 ## Privacy Policy
 

--- a/devserver.js
+++ b/devserver.js
@@ -1,0 +1,8 @@
+const http = require('http');
+const handler = require('./src/handler.js');
+
+http.createServer((req, res) => handler(req, res))
+  .listen(3000);
+
+console.log('Dev server is running');
+console.log('Example request: http://localhost:3000/?npm=react');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "pretest": "eslint .",
+    "dev": "nodemon devserver.js",
     "test": "jest"
   },
   "dependencies": {
@@ -20,6 +21,9 @@
     "mixpanel": "^0.11.0",
     "p-map": "^4.0.0",
     "tldjs": "^2.3.1"
+  },
+  "peerDependencies": {
+    "nodemon": "*"
   },
   "devDependencies": {
     "jsdom": "^16.2.2",


### PR DESCRIPTION
Working on this service without using `now dev` is not that straight forward and requires creating a server yourself. This Pull Requests adds `npm run dev` which spins up a local dev-server using the Node.js build-in `http` module and `nodemon` for auto refresh. 