### PR TITLE
Add support for pub.dev registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The supported registries are:
 - [pypi.python.org](https://pypi.python.org)
 - [crates.io](https://crates.io)
 - [melpa.org](https://melpa.org)
+- [pub.dev/](https://pub.dev/)
 
 Example:
 
@@ -41,6 +42,7 @@ Type must be one of:
 - `crates`
 - `java`
 - `go`
+- `pub`
 - `ping`
 
 Response:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The supported registries are:
 - [pypi.python.org](https://pypi.python.org)
 - [crates.io](https://crates.io)
 - [melpa.org](https://melpa.org)
-- [pub.dev/](https://pub.dev/)
+- [pub.dev/](https://pub.dev)
 
 Example:
 

--- a/functional.spec.js
+++ b/functional.spec.js
@@ -119,4 +119,9 @@ describe('functional', () => {
     'https://nodejs.org/api/path.html',
     'https://nodejs.org/api/path.html',
   );
+  testBulk(
+    'pub',
+    'path',
+    'https://github.com/dart-lang/path',
+  );
 });

--- a/src/registries/config.json
+++ b/src/registries/config.json
@@ -48,6 +48,13 @@
         "/info/package_url"
       ]
     },
+    "pub": {
+      "registry": "https://pub.dev/api/packages/%s",
+      "fallback": "https://pub.dev/packages/%s",
+      "xpaths": [
+        "/latest/pubspec/homepage"
+      ]
+    },
     "crates": {
       "registry": "https://crates.io/api/v1/crates/%s",
       "fallback": "https://crates.io/crates/%s",


### PR DESCRIPTION
@xt0rted started working on adding Dart support to OctoLinker and this is the counter part to resolve Dart dependencies using the OctoLinker API.

Preview https://octolinker-api-git-support-pub.octolinker1.now.sh/?pub=connectivity