### PR TITLE
Add nuget support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.js text eol=lf

--- a/functional.spec.js
+++ b/functional.spec.js
@@ -139,4 +139,14 @@ describe('functional', () => {
     'boot',
     'https://github.com/cran/boot',
   );
+  testBulk(
+    'nuget',
+    'Notify',
+    'https://www.nuget.org/packages/notify/',
+  );
+  testBulk(
+    'nuget',
+    'QRCoder',
+    'https://github.com/codebude/QRCoder',
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6832,6 +6832,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -7957,6 +7962,14 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
       "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
       "dev": true
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
+      }
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "micro": "^9.3.3",
     "mixpanel": "^0.13.0",
     "p-map": "^4.0.0",
-    "tldjs": "^2.3.1"
+    "tldjs": "^2.3.1",
+    "xml-js": "^1.6.11"
   },
   "peerDependencies": {
     "nodemon": "*"

--- a/src/handler.js
+++ b/src/handler.js
@@ -4,6 +4,7 @@ const pMap = require('p-map');
 
 const go = require('./go');
 const java = require('./java');
+const nuget = require('./nuget');
 const ping = require('./ping');
 const registries = require('./registries');
 
@@ -25,6 +26,8 @@ const mapper = async (item) => {
     result = await java(item.target);
   } else if (item.type === 'ping') {
     result = await ping(item.target);
+  } else if (item.type === 'nuget') {
+    result = await nuget(item.target);
   } else {
     return;
   }

--- a/src/nuget.js
+++ b/src/nuget.js
@@ -1,0 +1,125 @@
+const findReachableUrls = require('find-reachable-urls');
+const got = require('got');
+const isUrl = require('is-url');
+const { xml2js } = require('xml-js');
+
+const cache = require('./utils/cache');
+const log = require('./utils/log');
+const repositoryUrl = require('./registries/repository-url');
+
+const getLatestVersion = async (pkg) => {
+  let response;
+  try {
+    response = await got.get(`https://api.nuget.org/v3-flatcontainer/${pkg}/index.json`);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      log('Package not found', pkg);
+      return;
+    }
+
+    log(err);
+    return;
+  }
+
+  let json;
+  try {
+    json = JSON.parse(response.body);
+  } catch (err) {
+    log('Parsing response failed');
+    return;
+  }
+
+  // The version list is in ascending order so we take the last one and hope it has the best url data
+  const [version] = json.versions.slice(-1);
+
+  return version;
+};
+
+const getProjectUrls = async (pkg, version) => {
+  let response;
+  try {
+    response = await got.get(`https://api.nuget.org/v3-flatcontainer/${pkg}/${version}/${pkg}.nuspec`);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      log('Package not found', pkg);
+      return;
+    }
+
+    log(err);
+    return;
+  }
+
+  let json;
+  try {
+    json = xml2js(response.body, { compact: true });
+  } catch (err) {
+    log('Parsing response failed');
+    return;
+  }
+
+  // Parsing is based on this version of the schema
+  // https://github.com/NuGet/NuGet.Client/blob/b82834821e19fd2a0489ef66f786939a38d435b5/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+  const { metadata: { repository, projectUrl: project } } = json.package;
+
+  const urls = [];
+
+  if (repository && repository._attributes) {
+    const { url } = repository._attributes;
+    urls.push(url);
+  }
+
+  if (project) {
+    const url = project._text;
+
+    // We only want to use the project url if it points to github because a lot of the times these go to corporate, project, or personal websites and aren't useful for us
+    if (url && url.startsWith('https://github.com')) {
+      urls.push(url);
+    }
+  }
+
+  return urls;
+};
+
+module.exports = async (pkg) => {
+  pkg = pkg.toLowerCase();
+
+  const cacheKey = `nuget_${pkg}`;
+  const cacheValue = await cache.get(cacheKey);
+
+  if (cacheValue) {
+    return cacheValue;
+  }
+
+  const packageVersion = await getLatestVersion(pkg);
+
+  if (!packageVersion) {
+    return undefined;
+  }
+
+  const urls = await getProjectUrls(pkg, packageVersion);
+
+  const validUrls = urls.map((bestMatchUrl) => {
+    try {
+      let url = repositoryUrl(bestMatchUrl);
+
+      if (!url && isUrl(bestMatchUrl)) {
+        url = bestMatchUrl;
+      }
+
+      return url;
+    } catch (err) {
+      return false;
+    }
+  });
+
+  const reachableUrl = await findReachableUrls(validUrls, { firstMatch: true });
+
+  if (!reachableUrl) {
+    log('No URL for package found, falling back to nuget.org');
+    return `https://www.nuget.org/packages/${pkg}/`;
+  }
+
+  await cache.set(cacheKey, reachableUrl);
+
+  return reachableUrl;
+};

--- a/src/utils/payload.js
+++ b/src/utils/payload.js
@@ -3,7 +3,7 @@ const isEqual = require('lodash.isequal');
 
 const registries = require('../registries');
 
-const supportedTypes = ['ping', 'go', 'java', ...registries.supported];
+const supportedTypes = ['ping', 'go', 'java', 'nuget', ...registries.supported];
 
 module.exports = function (payload) {
   // Remove invalid items which does not follow format {type:'foo', target: 'bar'}


### PR DESCRIPTION
This is using optional chaining which works in node 14+ from what I can tell, so we might need to increase the node version the api runs on, or refactor the code so it doesn't use that feature.

Version endpoint: https://api.nuget.org/v3-flatcontainer/qrcoder/index.json
Package endpoint: https://api.nuget.org/v3-flatcontainer/qrcoder/1.3.9/qrcoder.nuspec