### PR TITLE
Reduce severless execution time by increasing cache duration

### DIFF
--- a/src/ping.js
+++ b/src/ping.js
@@ -24,7 +24,7 @@ module.exports = async function (url) {
       return url;
     })
     .catch(async () => {
-      await cache.set(cacheKey, ERR_PING_NOT_FOUND, 900); // 15 minutes
+      await cache.set(cacheKey, ERR_PING_NOT_FOUND);
 
       return undefined;
     });

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -41,7 +41,7 @@ async function resolve(type, packageName) {
   } catch (err) {
     if (err.statusCode === 404) {
       log('Package not found', packageName, type);
-      await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND, 900); // 15 minutes
+      await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND);
       return;
     }
 
@@ -53,7 +53,7 @@ async function resolve(type, packageName) {
     json = JSON.parse(response.body);
   } catch (err) {
     log('Parsing response failed');
-    await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND, 900); // 15 minutes
+    await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND);
     return;
   }
 
@@ -103,7 +103,7 @@ async function resolve(type, packageName) {
 
   if (!reachableUrl) {
     log('No URL for package found');
-    await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND, 900); // 15 minutes
+    await cache.set(cacheKey, ERR_PACKAGE_NOT_FOUND);
     return;
   }
 

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -22,7 +22,7 @@ const redisUrls = {
 };
 
 const availableRegions = ['dev1', 'bru1', 'gru1', 'hnd1', 'iad1', 'sfo1'];
-const defaultExpireValue = 3600 * 12;
+const defaultExpireValue = 3600 * 48;
 
 let redis;
 const simpleCache = new Map();

--- a/src/utils/cache.spec.js
+++ b/src/utils/cache.spec.js
@@ -88,7 +88,7 @@ describe('cache', () => {
           'redis-foo',
           'redis-bar',
           'EX',
-          3600 * 12,
+          3600 * 48,
         );
       });
     });


### PR DESCRIPTION
Increase cache TTL from 12 hours to 48 hours. Unresolved pings were cached 15min, now also 48 hours. This change is required to reduce the serverless invocation time which is noticeable high right now. 